### PR TITLE
Improve mock Twitter client and check parsing robustness

### DIFF
--- a/src/main/scala/dev/rennie/tweetingester/StreamingClientBuilder.scala
+++ b/src/main/scala/dev/rennie/tweetingester/StreamingClientBuilder.scala
@@ -6,7 +6,7 @@ import org.http4s.client.blaze.BlazeClientBuilder
 
 /** Builders which produce a singleton stream containing a [[Client]].
   *
-  * Used to hide [[BlazeClientBuilder]] behind a generic trait so it can be
+  * Used to hide [[BlazeClientBuilder]] behind a trait so it can be
   * mocked in testing.
   */
 trait StreamingClientBuilder[F[_]] {

--- a/src/test/scala/dev/rennie/tweetingester/mock/CrlfDelimitedJsonEncoder.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/CrlfDelimitedJsonEncoder.scala
@@ -2,11 +2,13 @@ package dev.rennie.tweetingester.mock
 
 import java.nio.charset.StandardCharsets
 
+import cats.Applicative
 import dev.rennie.tweetingester.Tweet
 import fs2.Stream
-import io.circe.{Encoder, Json}
+import io.circe.{Encoder, Json, Printer}
 import io.circe.syntax._
 import org.http4s
+import org.http4s.circe.CirceInstances
 import org.http4s.headers.{`Content-Type`, `Transfer-Encoding`}
 import org.http4s.{
   Entity,
@@ -23,20 +25,24 @@ import org.http4s.{
   * separated by `\r\n` (CRLF). The JSON objects may contain newlines, `\n`, but
   * not the CRLF sequence.
   */
-class CrlfDelimitedJsonEncoder[F[_], O](
-    implicit jsonEncoder: Encoder[O],
-    entityEncoder: EntityEncoder[F, Json]
+class CrlfDelimitedJsonEncoder[F[_]: Applicative, O](
+    implicit jsonEncoder: Encoder[O]
 ) extends EntityEncoder[F, Stream[F, Seq[O]]] {
 
   private val delimiter: String = "\r\n"
   private val delimiterBody: EntityBody[F] =
     Stream.emits(delimiter.getBytes(StandardCharsets.UTF_8))
 
+  val jsonEntityEncoder: EntityEncoder[F, Json] = CirceInstances
+    .withPrinter(Printer.spaces4) // output with indentation and line feeds
+    .build
+    .jsonEncoder[F]
+
   override def toEntity(stream: Stream[F, Seq[O]]): Entity[F] = Entity(
     for {
       els <- stream
       el <- Stream.emits(els)
-      delimited <- entityEncoder.toEntity(el.asJson).body ++ delimiterBody
+      delimited <- jsonEntityEncoder.toEntity(el.asJson).body ++ delimiterBody
     } yield delimited
   )
 
@@ -47,9 +53,8 @@ class CrlfDelimitedJsonEncoder[F[_], O](
 }
 
 object CrlfDelimitedJsonEncoderInstances {
-  implicit def tweetDelimitedJsonEncoder[F[_]](
-      implicit jsonEncoder: Encoder[Tweet],
-      entityEncoder: EntityEncoder[F, Json]
+  implicit def tweetDelimitedJsonEncoder[F[_]: Applicative](
+      implicit jsonEncoder: Encoder[Tweet]
   ): EntityEncoder[F, Stream[F, Seq[Tweet]]] =
     new CrlfDelimitedJsonEncoder[F, Tweet]()
 }

--- a/src/test/scala/dev/rennie/tweetingester/mock/CrlfDelimitedJsonEncoder.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/CrlfDelimitedJsonEncoder.scala
@@ -22,7 +22,7 @@ import org.http4s.{
 /** Encodes sequences of objects as CRLF-delimited JSON value streams.
   *
   * Given a streamed sequence of objects `O`, encodes each `O` as a JSON object
-  * separated by `\r\n` (CRLF). The JSON objects may contain newlines, `\n`, but
+  * separated by `\r\n` (CRLF). The JSON objects may contain newlines `\n` but
   * not the CRLF sequence.
   *
   * Optionally, `\n` elements may appear between tweets which is used to keep
@@ -49,8 +49,10 @@ class CrlfDelimitedJsonEncoder[F[_]: Applicative, O](keepAlive: Boolean)(
     for {
       els <- stream
       el <- Stream.emits(els)
-      delimiters = if (keepAlive) delimiterBody ++ keepAliveBody
-      else delimiterBody
+      delimiters = if (keepAlive)
+        delimiterBody ++ keepAliveBody
+      else
+        delimiterBody
 
       delimited <- jsonEntityEncoder.toEntity(el.asJson).body ++ delimiters
     } yield delimited

--- a/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClient.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClient.scala
@@ -26,6 +26,7 @@ class MockTwitterClient[F[_]](val enc: EntityEncoder[F, Stream[F, Seq[Tweet]]])(
 }
 
 object MockTwitterClient {
+  // TODO: provide constructors with keep-alive flag that import relevant encoder
 
   /** Summons a [[MockTwitterClient]] for effect type `F`. */
   def apply[F[_]]()(implicit F: Sync[F],

--- a/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClient.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClient.scala
@@ -26,10 +26,24 @@ class MockTwitterClient[F[_]](val enc: EntityEncoder[F, Stream[F, Seq[Tweet]]])(
 }
 
 object MockTwitterClient {
-  // TODO: provide constructors with keep-alive flag that import relevant encoder
 
-  /** Summons a [[MockTwitterClient]] for effect type `F`. */
-  def apply[F[_]]()(implicit F: Sync[F],
-                    enc: EntityEncoder[F, Stream[F, Seq[Tweet]]]) =
+  /**
+    * Summons a [[MockTwitterClient]] for effect type `F`.
+    *
+    * @param emitKeepAlive if true, the client emits delimiters `\r\n` and keep
+    *                      alive `\n` chars between tweet elements, else it only
+    *                      emits the delimiters `\r\n`.
+    * @return a client which mocks the Twitter API behaviour
+    */
+  def apply[F[_]](
+      emitKeepAlive: Boolean
+  )(implicit F: Sync[F]): MockTwitterClient[F] = {
+    val enc =
+      if (emitKeepAlive)
+        CrlfDelimitedJsonEncoderInstances.tweetDelimitedKeepAliveJsonEncoder
+      else
+        CrlfDelimitedJsonEncoderInstances.tweetDelimitedJsonEncoder
+
     new MockTwitterClient[F](enc)
+  }
 }

--- a/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClientSpec.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClientSpec.scala
@@ -9,6 +9,7 @@ import io.circe.syntax._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 
+/** Tests that the mock client provides the expected behaviour. */
 final class MockTwitterClientSpec extends BaseTestSpec {
   implicit val tweetArbitrary: Arbitrary[Tweet] = Arbitrary(tweetGen)
   val client = new MockTwitterClient[IO](tweetDelimitedJsonEncoder[IO])
@@ -34,7 +35,7 @@ final class MockTwitterClientSpec extends BaseTestSpec {
           .unsafeRunSync()
 
         val expected =
-          ts.foldLeft("")((res, el) => res ++ el.asJson.noSpaces ++ "\r\n")
+          ts.foldLeft("")((res, el) => res ++ el.asJson.spaces4 ++ "\r\n")
 
         body should equal(expected)
       }

--- a/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClientSpec.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClientSpec.scala
@@ -3,6 +3,7 @@ package dev.rennie.tweetingester.mock
 import cats.effect.IO
 import dev.rennie.tweetingester.{BaseTestSpec, Tweet}
 import dev.rennie.tweetingester.mock.CrlfDelimitedJsonEncoderInstances.tweetDelimitedJsonEncoder
+import dev.rennie.tweetingester.mock.CrlfDelimitedJsonEncoderInstances.tweetDelimitedKeepAliveJsonEncoder
 import org.http4s.Request
 import org.http4s.circe._
 import io.circe.syntax._
@@ -27,15 +28,42 @@ final class MockTwitterClientSpec extends BaseTestSpec {
     }
 
     it("should respond with tweets as JSON separated by CRLF") {
-      forAll { ts: Seq[Tweet] =>
+      forAll { tweets: Seq[Tweet] =>
         val c =
-          client.returnsOkWith(ts).compile.toList.unsafeRunSync().head
+          client.returnsOkWith(tweets).compile.toList.unsafeRunSync().head
         val body = c
           .fetch(Request[IO]())(resp => resp.bodyAsText.compile.string)
           .unsafeRunSync()
 
         val expected =
-          ts.foldLeft("")((res, el) => res ++ el.asJson.spaces4 ++ "\r\n")
+          tweets.foldLeft("")((res, el) => res ++ el.asJson.spaces4 ++ "\r\n")
+
+        body should equal(expected)
+      }
+    }
+
+    it(
+      "should respond with tweets as JSON separated by CRLF with keep-alive signal"
+    ) {
+      // init a client that encodes with the keep-alive signal
+      val keepAliveClient =
+        new MockTwitterClient[IO](tweetDelimitedKeepAliveJsonEncoder[IO])
+
+      forAll { tweets: Seq[Tweet] =>
+        val c = keepAliveClient
+          .returnsOkWith(tweets)
+          .compile
+          .toList
+          .unsafeRunSync()
+          .head
+        val body = c
+          .fetch(Request[IO]())(resp => resp.bodyAsText.compile.string)
+          .unsafeRunSync()
+
+        val expected =
+          tweets.foldLeft("")(
+            (res, el) => res ++ el.asJson.spaces4 ++ "\r\n" ++ "\n"
+          )
 
         body should equal(expected)
       }

--- a/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClientSpec.scala
+++ b/src/test/scala/dev/rennie/tweetingester/mock/MockTwitterClientSpec.scala
@@ -2,18 +2,16 @@ package dev.rennie.tweetingester.mock
 
 import cats.effect.IO
 import dev.rennie.tweetingester.{BaseTestSpec, Tweet}
-import dev.rennie.tweetingester.mock.CrlfDelimitedJsonEncoderInstances.tweetDelimitedJsonEncoder
-import dev.rennie.tweetingester.mock.CrlfDelimitedJsonEncoderInstances.tweetDelimitedKeepAliveJsonEncoder
 import org.http4s.Request
-import org.http4s.circe._
 import io.circe.syntax._
 import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary._
 
 /** Tests that the mock client provides the expected behaviour. */
 final class MockTwitterClientSpec extends BaseTestSpec {
   implicit val tweetArbitrary: Arbitrary[Tweet] = Arbitrary(tweetGen)
-  val client = new MockTwitterClient[IO](tweetDelimitedJsonEncoder[IO])
+
+  val client: MockTwitterClient[IO] =
+    MockTwitterClient[IO](emitKeepAlive = false)
 
   describe("MockTwitterClient#returnsOkWith") {
     it("should return a singleton stream") {
@@ -47,7 +45,7 @@ final class MockTwitterClientSpec extends BaseTestSpec {
     ) {
       // init a client that encodes with the keep-alive signal
       val keepAliveClient =
-        new MockTwitterClient[IO](tweetDelimitedKeepAliveJsonEncoder[IO])
+        MockTwitterClient[IO](emitKeepAlive = true)
 
       forAll { tweets: Seq[Tweet] =>
         val c = keepAliveClient


### PR DESCRIPTION
- improved mock Twitter client to return CRLF and/or LF chars (`\r\n`, `\n`) between each tweet JSON object, imitating the real Twitter stream.
- expanded tests to confirm the stream parser correctly outputs tweets under new mock behaviour (it did!)

A future story should investigate non-tweet JSON objects that the stream can apparently return (e.g. warnings and errors) but this is enough for now to close #14.
